### PR TITLE
Remove recursive os.walk on directories matching ignore list

### DIFF
--- a/bugcatcher/ftl.py
+++ b/bugcatcher/ftl.py
@@ -194,11 +194,6 @@ def process_dir(to_submit, fn, extensions):
         # We know we are in a directory
         is_directory = True
 
-        # This isn't ideal, but will work for most projects and I can
-        # write a more intelligent version if it becomes neccessary.
-        pieces = os.path.normpath(eval_dir_name).split(os.path.sep)
-        # truncated_dir_name = (os.path.sep).join(pieces[base_path_index:]) + os.path.sep
-        
         ignore = False
 
         for ignore_re in path_ignore_pieces:

--- a/bugcatcher/ftl.py
+++ b/bugcatcher/ftl.py
@@ -197,14 +197,14 @@ def process_dir(to_submit, fn, extensions):
         ignore = False
 
         for ignore_re in path_ignore_pieces:
-            # Remove any subdirectories matching the ignore list
-            for subdir in sub_dir_list:
-                if ignore_re.search(subdir):
-                    sub_dir_list[:] = [d for d in sub_dir_list if not d == subdir]
             # Ignore this directory?
             if ignore_re.search(eval_dir_name):
                 ignore = True
                 break
+            # Remove any subdirectories matching the ignore list
+            for subdir in sub_dir_list:
+                if ignore_re.search(subdir):
+                    sub_dir_list[:] = [d for d in sub_dir_list if not d == subdir]
 
         if not ignore:
             to_submit = add_to_push_list(

--- a/bugcatcher/ftl.py
+++ b/bugcatcher/ftl.py
@@ -188,7 +188,7 @@ def process_dir(to_submit, fn, extensions):
     for dir_name, sub_dir_list, file_list in os.walk(fn, topdown=True):
         # Clean up the dir_name for evaluation later
         eval_dir_name = dir_name
-        if dir_name.startswith('./'):
+        if dir_name.startswith('.' + os.path.sep):
             eval_dir_name = dir_name[2:]
 
         # We know we are in a directory

--- a/bugcatcher/ftl.py
+++ b/bugcatcher/ftl.py
@@ -215,9 +215,8 @@ def process_dir(to_submit, fn, extensions):
                 to_submit
             )
         else:
-            # Ignore this directory and everything in it
+            # Ignore this directory and prevent its subdirectories from being walked further
             sub_dir_list[:] = []
-            file_list[:] = []
 
     if not is_directory:
         to_submit = add_to_push_list(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='bugcatcher',
-    version='0.1.2',
+    version='0.1.3',
     author='Faster Than Light',
     author_email='devops@fasterthanlight.dev',
     maintainer='Faster Than Light',


### PR DESCRIPTION
See #10 

We were recursively walking the file tree even in subdirectories that fit our ignore list. The files were not being added to our upload queue, but a lot of resources were spent iterating through the subdirectories even though they would not be uploaded. When a dir like `node_modules` has 30k files, it really slows the client down. I'm seeing **drastic** improvements now.